### PR TITLE
Enable failover broker within ADC

### DIFF
--- a/demo_artemis_failover.py
+++ b/demo_artemis_failover.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Integration test script to demonstrate Artemis Data Collector failover functionality.
+
+This script shows how the failover mechanism works by simulating primary broker failures.
+"""
+
+import sys
+from unittest.mock import Mock, patch
+
+import requests
+
+# Add the source directory to path
+sys.path.insert(0, "src")
+
+from artemis_data_collector.artemis_data_collector import ArtemisDataCollector, parse_args
+
+
+def demo_failover():
+    """Demonstrate the failover functionality"""
+    print("=== Artemis Data Collector Failover Demo ===\n")
+
+    # Parse configuration with failover
+    config = parse_args(
+        [
+            "--artemis_url",
+            "http://primary:8161",
+            "--artemis_failover_url",
+            "http://failover:8161",
+            "--database_hostname",
+            "localhost",
+            "--queue_list",
+            "TEST_QUEUE",
+            "--log_level",
+            "INFO",
+        ]
+    )
+
+    print(f"Primary URL: {config.artemis_url}")
+    print(f"Failover URL: {config.artemis_failover_url}")
+    print()
+
+    # Mock the database and requests to simulate scenarios
+    with (
+        patch("artemis_data_collector.artemis_data_collector.psycopg.connect") as mock_connect,
+        patch("artemis_data_collector.artemis_data_collector.requests.Session") as mock_session_class,
+    ):
+        # Mock database
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_cursor.fetchall.return_value = [("1", "TEST_QUEUE")]
+        mock_cursor_context = Mock()
+        mock_cursor_context.__enter__ = Mock(return_value=mock_cursor)
+        mock_cursor_context.__exit__ = Mock(return_value=None)
+        mock_conn.cursor.return_value = mock_cursor_context
+        mock_connect.return_value = mock_conn
+
+        # Mock session
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        print("Scenario 1: Primary broker working")
+        print("-" * 40)
+
+        # Mock successful primary response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"status": 200, "value": ["TEST_QUEUE"]}
+        mock_session.get.return_value = mock_response
+
+        try:
+            adc = ArtemisDataCollector(config)
+            result = adc.request_activemq("/AddressNames")
+            print(f"✓ Primary broker returned: {result}")
+            print(f"  Requests made: {mock_session.get.call_count}")
+        except Exception as e:
+            print(f"✗ Error: {e}")
+
+        print()
+
+        print("Scenario 2: Primary fails, failover succeeds")
+        print("-" * 40)
+
+        # Reset call count
+        mock_session.reset_mock()
+
+        # Mock primary failure and failover success
+        mock_response_fail = Mock()
+        mock_response_fail.status_code = 500
+
+        mock_response_success = Mock()
+        mock_response_success.status_code = 200
+        mock_response_success.json.return_value = {"status": 200, "value": ["TEST_QUEUE"]}
+
+        # First call (init) succeeds, second call (primary) fails, third call (failover) succeeds
+        mock_session.get.side_effect = [mock_response_success, mock_response_fail, mock_response_success]
+
+        try:
+            adc = ArtemisDataCollector(config)
+            result = adc.request_activemq("/AddressNames")
+            print(f"✓ Failover broker returned: {result}")
+            print(f"  Total requests made: {mock_session.get.call_count}")
+            print("  → Primary failed, failover succeeded")
+        except Exception as e:
+            print(f"✗ Error: {e}")
+
+        print()
+
+        print("Scenario 3: Primary fails with connection error, failover succeeds")
+        print("-" * 40)
+
+        # Reset call count
+        mock_session.reset_mock()
+
+        # Mock connection exception and failover success
+        mock_session.get.side_effect = [
+            mock_response_success,  # Init call
+            requests.exceptions.ConnectionError("Connection failed"),  # Primary fails
+            mock_response_success,  # Failover succeeds
+        ]
+
+        try:
+            adc = ArtemisDataCollector(config)
+            result = adc.request_activemq("/AddressNames")
+            print(f"✓ Failover broker returned: {result}")
+            print(f"  Total requests made: {mock_session.get.call_count}")
+            print("  → Primary threw ConnectionError, failover succeeded")
+        except Exception as e:
+            print(f"✗ Error: {e}")
+
+        print()
+
+        print("Scenario 4: Both primary and failover fail")
+        print("-" * 40)
+
+        # Reset call count
+        mock_session.reset_mock()
+
+        # Mock both failing
+        mock_session.get.side_effect = [
+            mock_response_success,  # Init call
+            mock_response_fail,  # Primary fails
+            mock_response_fail,  # Failover fails
+        ]
+
+        try:
+            adc = ArtemisDataCollector(config)
+            result = adc.request_activemq("/AddressNames")
+            print(f"✗ Both brokers failed, result: {result}")
+            print(f"  Total requests made: {mock_session.get.call_count}")
+            print("  → Both primary and failover failed")
+        except Exception as e:
+            print(f"✗ Error: {e}")
+
+        print("\n=== Demo completed ===")
+
+
+def demo_configuration():
+    """Demonstrate configuration options"""
+    print("\n=== Configuration Options Demo ===\n")
+
+    print("Configuration with failover:")
+    config_with_failover = parse_args(
+        ["--artemis_url", "http://primary:8161", "--artemis_failover_url", "http://failover:8161"]
+    )
+    print(f"  Primary URL: {config_with_failover.artemis_url}")
+    print(f"  Failover URL: {config_with_failover.artemis_failover_url}")
+
+    print("\nConfiguration without failover:")
+    config_without_failover = parse_args(["--artemis_url", "http://primary:8161"])
+    print(f"  Primary URL: {config_without_failover.artemis_url}")
+    print(f"  Failover URL: {config_without_failover.artemis_failover_url}")
+
+    print("\nEnvironment variable configuration:")
+    import os
+
+    os.environ["ARTEMIS_FAILOVER_URL"] = "http://env-failover:8161"
+    try:
+        config_env = parse_args([])
+        print(f"  Failover URL from env: {config_env.artemis_failover_url}")
+    finally:
+        if "ARTEMIS_FAILOVER_URL" in os.environ:
+            del os.environ["ARTEMIS_FAILOVER_URL"]
+
+
+if __name__ == "__main__":
+    demo_configuration()
+    demo_failover()

--- a/src/artemis_data_collector/artemis_data_collector.py
+++ b/src/artemis_data_collector/artemis_data_collector.py
@@ -38,11 +38,15 @@ class ArtemisDataCollector:
         self._conn = None
 
         # common session for all requests
-        self._session = self._session = requests.Session()
+        self._session = requests.Session()
         self._session.auth = (self.config.artemis_user, self.config.artemis_password)
         self._session.headers.update({"Origin": "localhost"})
 
+        # Build primary and failover base URLs
         self.base_url = f"{self.config.artemis_url}/console/jolokia/read/org.apache.activemq.artemis:broker=%22{self.config.artemis_broker_name}%22"  # noqa: E501
+        self.base_failover_url = None
+        if hasattr(self.config, "artemis_failover_url") and self.config.artemis_failover_url:
+            self.base_failover_url = f"{self.config.artemis_failover_url}/console/jolokia/read/org.apache.activemq.artemis:broker=%22{self.config.artemis_broker_name}%22"  # noqa: E501
 
         database_statusqueues = self.get_database_statusqueues()
         amq_queues = self.get_activemq_queues()
@@ -95,26 +99,47 @@ class ArtemisDataCollector:
             time.sleep(self.config.interval)
 
     def request_activemq(self, query):
-        """Make a request to ActiveMQ Artemis Jolokia API"""
+        """Make a request to ActiveMQ Artemis Jolokia API with failover support"""
+        # Try primary URL first
         try:
             response = self.session.get(self.base_url + query)
+            if response.status_code == 200:
+                try:
+                    json_response = response.json()
+                    if json_response["status"] == 200:
+                        return json_response["value"]
+                    else:
+                        logger.error(f"Primary broker error: {json_response}")
+                except requests.exceptions.JSONDecodeError:
+                    logger.error(f"Primary broker JSON decode error: {response.text}")
+            else:
+                logger.error(f"Primary broker HTTP error {response.status_code}: {response.text}")
         except requests.exceptions.RequestException as e:
-            logger.error(e)
-            return None
+            logger.error(f"Primary broker connection error: {e}")
 
-        if response.status_code != 200:
-            logger.error(f"Error: {response.text}")
-            return None
+        # If primary fails and failover is configured, try failover URL
+        if self.base_failover_url:
+            logger.info("Primary broker failed, trying failover broker")
+            try:
+                response = self.session.get(self.base_failover_url + query)
+                if response.status_code == 200:
+                    try:
+                        json_response = response.json()
+                        if json_response["status"] == 200:
+                            logger.info("Successfully connected to failover broker")
+                            return json_response["value"]
+                        else:
+                            logger.error(f"Failover broker error: {json_response}")
+                    except requests.exceptions.JSONDecodeError:
+                        logger.error(f"Failover broker JSON decode error: {response.text}")
+                else:
+                    logger.error(f"Failover broker HTTP error {response.status_code}: {response.text}")
+            except requests.exceptions.RequestException as e:
+                logger.error(f"Failover broker connection error: {e}")
+        else:
+            logger.warning("No failover broker configured")
 
-        try:
-            if response.json()["status"] != 200:
-                logger.error(f"Error: {response.json()}")
-                return None
-        except requests.exceptions.JSONDecodeError:
-            logger.error(f"JSON decode Error: {response.text}")
-            return None
-
-        return response.json()["value"]
+        return None
 
     def get_activemq_queues(self):
         """Returns a list of queues from the Artemis"""
@@ -171,7 +196,7 @@ class ArtemisDataCollector:
 
 def parse_args(args):
     # parse command line arguments where values can alternavitly be set via environment variables
-    parser = argparse.ArgumentParser(description="Collect data from Artemis")
+    parser = argparse.ArgumentParser(description="Collect data from Artemis with failover support")
     parser.add_argument("--version", action="version", version="%(prog)s 1.0")
     parser.add_argument(
         "--initialize_db",
@@ -179,7 +204,14 @@ def parse_args(args):
         help="Initialize the database tables and exit. Will fail if tables already exist",
     )
     parser.add_argument(
-        "--artemis_url", default=environ.get("ARTEMIS_URL", "http://localhost:8161"), help="URL of the Artemis instance"
+        "--artemis_url", 
+        default=environ.get("ARTEMIS_URL", "http://localhost:8161"), 
+        help="URL of the primary Artemis instance"
+    )
+    parser.add_argument(
+        "--artemis_failover_url",
+        default=environ.get("ARTEMIS_FAILOVER_URL"),
+        help="URL of the failover Artemis instance (optional)",
     )
     parser.add_argument(
         "--artemis_user", default=environ.get("ARTEMIS_USER", "artemis"), help="User of the Artemis instance"

--- a/tests/test_artemis_data_collector_failover.py
+++ b/tests/test_artemis_data_collector_failover.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""
+Unit tests for Artemis Data Collector failover functionality.
+
+These tests verify that the failover mechanism works correctly when the primary
+broker fails and a failover broker is configured.
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+
+import requests
+
+from artemis_data_collector.artemis_data_collector import ArtemisDataCollector, parse_args
+
+
+class TestArtemisDataCollectorFailover(unittest.TestCase):
+    def setUp(self):
+        """Set up test configuration with failover URL"""
+        self.config = Mock()
+        self.config.artemis_url = "http://primary:8161"
+        self.config.artemis_failover_url = "http://failover:8161"
+        self.config.artemis_user = "admin"
+        self.config.artemis_password = "admin"
+        self.config.artemis_broker_name = "0.0.0.0"
+        self.config.database_hostname = "localhost"
+        self.config.database_port = 5432
+        self.config.database_user = "workflow"
+        self.config.database_password = "workflow"
+        self.config.database_name = "workflow"
+        self.config.queue_list = ["TEST_QUEUE"]
+        self.config.interval = 600
+        self.config.log_level = "INFO"
+
+    def _create_mock_cursor_context(self, mock_cursor):
+        """Helper method to create a mock cursor context manager"""
+        mock_context = Mock()
+        mock_context.__enter__ = Mock(return_value=mock_cursor)
+        mock_context.__exit__ = Mock(return_value=None)
+        return mock_context
+
+    @patch("artemis_data_collector.artemis_data_collector.psycopg.connect")
+    @patch("artemis_data_collector.artemis_data_collector.requests.Session")
+    def test_parse_args_with_failover(self, mock_session_class, mock_connect):
+        """Test that parse_args correctly handles failover URL"""
+        args = [
+            "--artemis_url", "http://primary:8161",
+            "--artemis_failover_url", "http://failover:8161",
+            "--database_hostname", "localhost",
+            "--queue_list", "TEST_QUEUE"
+        ]
+        
+        config = parse_args(args)
+        
+        self.assertEqual(config.artemis_url, "http://primary:8161")
+        self.assertEqual(config.artemis_failover_url, "http://failover:8161")
+
+    @patch("artemis_data_collector.artemis_data_collector.psycopg.connect")
+    @patch("artemis_data_collector.artemis_data_collector.requests.Session")
+    def test_parse_args_without_failover(self, mock_session_class, mock_connect):
+        """Test that parse_args works without failover URL"""
+        args = [
+            "--artemis_url", "http://primary:8161",
+            "--database_hostname", "localhost",
+            "--queue_list", "TEST_QUEUE"
+        ]
+        
+        config = parse_args(args)
+        
+        self.assertEqual(config.artemis_url, "http://primary:8161")
+        self.assertIsNone(config.artemis_failover_url)
+
+    @patch("artemis_data_collector.artemis_data_collector.psycopg.connect")
+    @patch("artemis_data_collector.artemis_data_collector.requests.Session")
+    def test_request_activemq_primary_success(self, mock_session_class, mock_connect):
+        """Test successful primary broker request"""
+        # Mock database connection and cursor
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_cursor.fetchall.return_value = [("1", "TEST_QUEUE")]
+        mock_conn.cursor.return_value = self._create_mock_cursor_context(mock_cursor)
+        mock_connect.return_value = mock_conn
+
+        # Mock session
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        # Mock successful responses
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"status": 200, "value": ["TEST_QUEUE"]}
+        mock_session.get.return_value = mock_response
+
+        adc = ArtemisDataCollector(self.config)
+        result = adc.request_activemq("/QueueNames")
+
+        # Should return primary response without trying failover
+        self.assertEqual(result, ["TEST_QUEUE"])
+        self.assertEqual(mock_session.get.call_count, 2)  # Init + request
+
+    @patch("artemis_data_collector.artemis_data_collector.psycopg.connect")
+    @patch("artemis_data_collector.artemis_data_collector.requests.Session")
+    def test_request_activemq_failover_success(self, mock_session_class, mock_connect):
+        """Test failover to secondary broker when primary fails"""
+        # Mock database connection and cursor
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_cursor.fetchall.return_value = [("1", "TEST_QUEUE")]
+        mock_conn.cursor.return_value = self._create_mock_cursor_context(mock_cursor)
+        mock_connect.return_value = mock_conn
+
+        # Mock session
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        # Mock init success, primary failure, failover success
+        mock_response_init = Mock()
+        mock_response_init.status_code = 200
+        mock_response_init.json.return_value = {"status": 200, "value": ["TEST_QUEUE"]}
+
+        mock_response_primary = Mock()
+        mock_response_primary.status_code = 500
+
+        mock_response_failover = Mock()
+        mock_response_failover.status_code = 200
+        mock_response_failover.json.return_value = {"status": 200, "value": {"TEST_QUEUE": "data"}}
+
+        mock_session.get.side_effect = [mock_response_init, mock_response_primary, mock_response_failover]
+
+        adc = ArtemisDataCollector(self.config)
+        result = adc.request_activemq("/QueueNames")
+
+        # Should return failover response
+        self.assertEqual(result, {"TEST_QUEUE": "data"})
+        self.assertEqual(mock_session.get.call_count, 3)  # Init + primary + failover
+
+    @patch("artemis_data_collector.artemis_data_collector.psycopg.connect")
+    @patch("artemis_data_collector.artemis_data_collector.requests.Session")
+    def test_request_activemq_primary_exception_failover_success(self, mock_session_class, mock_connect):
+        """Test failover when primary throws exception"""
+        # Mock database connection and cursor
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_cursor.fetchall.return_value = [("1", "TEST_QUEUE")]
+        mock_conn.cursor.return_value = self._create_mock_cursor_context(mock_cursor)
+        mock_connect.return_value = mock_conn
+
+        # Mock session
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        # First, mock the get_activemq_queues call (which should succeed for initialization)
+        mock_response_init = Mock()
+        mock_response_init.status_code = 200
+        mock_response_init.json.return_value = {"status": 200, "value": ["TEST_QUEUE"]}
+
+        mock_response_failover = Mock()
+        mock_response_failover.status_code = 200
+        mock_response_failover.json.return_value = {"status": 200, "value": {"TEST_QUEUE": "data"}}
+
+        # Set up the call sequence: init call succeeds, then primary throws exception, then failover succeeds
+        mock_session.get.side_effect = [
+            mock_response_init,  # get_activemq_queues
+            requests.exceptions.ConnectionError("Connection failed"),  # primary fails with exception
+            mock_response_failover,  # failover succeeds
+        ]
+
+        adc = ArtemisDataCollector(self.config)
+        result = adc.request_activemq("/QueueNames")
+
+        # Should return failover response
+        self.assertEqual(result, {"TEST_QUEUE": "data"})
+        self.assertEqual(mock_session.get.call_count, 3)  # Init + primary exception + failover
+
+    @patch("artemis_data_collector.artemis_data_collector.psycopg.connect")
+    @patch("artemis_data_collector.artemis_data_collector.requests.Session")
+    def test_request_activemq_no_failover_configured(self, mock_session_class, mock_connect):
+        """Test behavior when no failover is configured and primary fails"""
+        # Mock database connection and cursor
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_cursor.fetchall.return_value = [("1", "TEST_QUEUE")]
+        mock_conn.cursor.return_value = self._create_mock_cursor_context(mock_cursor)
+        mock_connect.return_value = mock_conn
+
+        # Create config without failover
+        config_no_failover = Mock()
+        config_no_failover.artemis_url = "http://primary:8161"
+        config_no_failover.artemis_failover_url = None
+        config_no_failover.artemis_user = "admin"
+        config_no_failover.artemis_password = "admin"
+        config_no_failover.artemis_broker_name = "0.0.0.0"
+        config_no_failover.database_hostname = "localhost"
+        config_no_failover.database_port = 5432
+        config_no_failover.database_user = "workflow"
+        config_no_failover.database_password = "workflow"
+        config_no_failover.database_name = "workflow"
+        config_no_failover.queue_list = ["TEST_QUEUE"]
+        config_no_failover.interval = 600
+        config_no_failover.log_level = "INFO"
+
+        # Mock session
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        # Mock init success, then primary failure
+        mock_response_init = Mock()
+        mock_response_init.status_code = 200
+        mock_response_init.json.return_value = {"status": 200, "value": ["TEST_QUEUE"]}
+
+        mock_response_primary = Mock()
+        mock_response_primary.status_code = 500
+
+        mock_session.get.side_effect = [mock_response_init, mock_response_primary]
+
+        adc = ArtemisDataCollector(config_no_failover)
+        result = adc.request_activemq("/QueueNames")
+
+        # Should return None when primary fails and no failover
+        self.assertIsNone(result)
+        self.assertEqual(mock_session.get.call_count, 2)  # Init + primary only
+
+    @patch("artemis_data_collector.artemis_data_collector.psycopg.connect")
+    @patch("artemis_data_collector.artemis_data_collector.requests.Session")
+    def test_request_activemq_both_fail(self, mock_session_class, mock_connect):
+        """Test behavior when both primary and failover fail"""
+        # Mock database connection and cursor
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_cursor.fetchall.return_value = [("1", "TEST_QUEUE")]
+        mock_conn.cursor.return_value = self._create_mock_cursor_context(mock_cursor)
+        mock_connect.return_value = mock_conn
+
+        # Mock session
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        # Mock successful init, then both primary and failover fail
+        mock_response_init = Mock()
+        mock_response_init.status_code = 200
+        mock_response_init.json.return_value = {"status": 200, "value": ["TEST_QUEUE"]}
+
+        mock_response_primary = Mock()
+        mock_response_primary.status_code = 500
+
+        mock_response_failover = Mock()
+        mock_response_failover.status_code = 500
+
+        mock_session.get.side_effect = [mock_response_init, mock_response_primary, mock_response_failover]
+
+        adc = ArtemisDataCollector(self.config)
+        result = adc.request_activemq("/QueueNames")
+
+        # Should return None when both fail
+        self.assertIsNone(result)
+        self.assertEqual(mock_session.get.call_count, 3)  # Init + primary + failover
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Short description of the changes:
Added failover broker support to Artemis Data Collector, allowing automatic switchover to a backup broker when the primary broker becomes unavailable.

# Long description of the changes:
This PR implements failover functionality for the Artemis Data Collector as requested in the user story. The implementation adds a new optional `--artemis_failover_url` parameter and corresponding `ARTEMIS_FAILOVER_URL` environment variable. When the primary broker fails (due to connection errors, HTTP errors, or malformed responses), the collector automatically attempts to connect to the failover broker.

Key changes:
- Enhanced `request_activemq()` method with comprehensive failover logic
- Added failover URL configuration in constructor
- Updated argument parser to accept failover URL parameter
- Added detailed logging for operational monitoring
- Maintains full backward compatibility - existing configurations work unchanged

The failover mechanism handles various failure scenarios including network timeouts, HTTP 4xx/5xx errors, connection refused, and JSON decode errors. When both brokers fail, the system logs appropriate errors and returns gracefully.

# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [x] I have added tests for my changes
- [x] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
1. **Test normal operation**: Run with only primary URL configured - should work as before
2. **Test failover configuration**: Run with both primary and failover URLs - should connect to primary
3. **Test failover trigger**: Block access to primary broker or stop primary service - should automatically switch to failover
4. **Test both brokers down**: Block both brokers - should log errors and handle gracefully
5. **Run the demo script**: `python demo_artemis_failover.py` to see all scenarios in action
6. **Check logs**: Verify appropriate log messages appear during failover events

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
[EWM # 11630](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=11630)